### PR TITLE
Update: Add "sensitivity" to the display encoding of an Errawr

### DIFF
--- a/pkg/encoding/display.go
+++ b/pkg/encoding/display.go
@@ -13,6 +13,7 @@ type ErrorDisplayEnvelope struct {
 	Section     string                           `json:"section"`
 	Code        string                           `json:"code"`
 	Title       string                           `json:"title"`
+	Sensitivity errawr.ErrorSensitivity          `json:"sensitivity,omitempty"`
 	Description *ErrorDescription                `json:"description,omitempty"`
 	Arguments   map[string]interface{}           `json:"arguments,omitempty"`
 	Items       map[string]*ErrorDisplayEnvelope `json:"items,omitempty"`
@@ -63,7 +64,7 @@ func (ede ErrorDisplayEnvelope) AsError() errawr.Error {
 		ErrorArguments:   arguments,
 		ErrorItems:       items,
 		ErrorMetadata:    &impl.ErrorMetadata{},
-		ErrorSensitivity: errawr.ErrorSensitivityEdge,
+		ErrorSensitivity: ede.Sensitivity,
 	}
 
 	for _, cause := range ede.Causes {
@@ -83,10 +84,11 @@ func ForDisplay(e errawr.Error) *ErrorDisplayEnvelope {
 
 func ForDisplayWithSensitivity(e errawr.Error, sensitivity errawr.ErrorSensitivity) *ErrorDisplayEnvelope {
 	ede := &ErrorDisplayEnvelope{
-		Domain:  e.Domain().Key(),
-		Section: e.Section().Key(),
-		Code:    e.ID(),
-		Title:   e.Title(),
+		Domain:      e.Domain().Key(),
+		Section:     e.Section().Key(),
+		Code:        e.ID(),
+		Title:       e.Title(),
+		Sensitivity: e.Sensitivity(),
 	}
 
 	if items, ok := e.Items(); ok {

--- a/pkg/encoding/display_test.go
+++ b/pkg/encoding/display_test.go
@@ -56,6 +56,24 @@ func TestDisplay(t *testing.T) {
 			Technical: "I am a cause.",
 		},
 	})
+	e = e.WithCause(&impl.Error{
+		Version: errawr.Version,
+		ErrorDomain: &impl.ErrorDomain{
+			Key:   "td",
+			Title: "Test Domain",
+		},
+		ErrorSection: &impl.ErrorSection{
+			Key:   "ts",
+			Title: "Test Section",
+		},
+		ErrorCode:  "test_bug",
+		ErrorTitle: "Test Error Bug",
+		ErrorDescription: &impl.ErrorDescription{
+			Friendly:  "I am a bug.",
+			Technical: "I am a bug.",
+		},
+		ErrorSensitivity: errawr.ErrorSensitivityBug,
+	})
 
 	b, err := json.Marshal(encoding.ForDisplay(e))
 	require.NoError(t, err)
@@ -87,6 +105,13 @@ func TestDisplay(t *testing.T) {
 					"friendly": "I am a cause.",
 					"technical": "I am a cause."
 				}
+			},
+			{
+				"domain": "td",
+				"section": "ts",
+				"code": "td_ts_test_bug",
+				"title": "Test Error Bug",
+				"sensitivity": 200
 			}
 		]
 	}`, string(b))
@@ -112,7 +137,7 @@ func TestDisplay(t *testing.T) {
 			"test": &impl.ErrorArgument{Value: true},
 		},
 		ErrorMetadata:    &impl.ErrorMetadata{},
-		ErrorSensitivity: errawr.ErrorSensitivityEdge,
+		ErrorSensitivity: errawr.ErrorSensitivityNone,
 	}
 	expected = expected.WithCause(&impl.Error{
 		Version: errawr.Version,
@@ -130,7 +155,22 @@ func TestDisplay(t *testing.T) {
 		},
 		ErrorArguments:   impl.ErrorArguments{},
 		ErrorMetadata:    &impl.ErrorMetadata{},
-		ErrorSensitivity: errawr.ErrorSensitivityEdge,
+		ErrorSensitivity: errawr.ErrorSensitivityNone,
+	})
+	expected = expected.WithCause(&impl.Error{
+		Version: errawr.Version,
+		ErrorDomain: &impl.ErrorDomain{
+			Key: e.Causes()[1].Domain().Key(),
+		},
+		ErrorSection: &impl.ErrorSection{
+			Key: e.Causes()[1].Section().Key(),
+		},
+		ErrorCode:        e.Causes()[1].Code(),
+		ErrorTitle:       e.Causes()[1].Title(),
+		ErrorDescription: &impl.ErrorDescription{},
+		ErrorArguments:   impl.ErrorArguments{},
+		ErrorMetadata:    &impl.ErrorMetadata{},
+		ErrorSensitivity: errawr.ErrorSensitivityBug,
 	})
 
 	require.Equal(t, expected, ede.AsError())
@@ -143,6 +183,7 @@ func TestDisplay(t *testing.T) {
 		"domain": "td",
 		"section": "ts",
 		"code": "td_ts_test",
-		"title": "Test Error"
+		"title": "Test Error",
+		"sensitivity": 200
 	}`, string(b))
 }

--- a/pkg/impl/copy.go
+++ b/pkg/impl/copy.go
@@ -54,9 +54,10 @@ func Copy(e errawr.Error) *Error {
 			Friendly:  e.Description().Friendly(),
 			Technical: e.Description().Technical(),
 		},
-		ErrorArguments: eas,
-		ErrorItems:     eis,
-		ErrorMetadata:  metadata,
+		ErrorArguments:   eas,
+		ErrorItems:       eis,
+		ErrorMetadata:    metadata,
+		ErrorSensitivity: e.Sensitivity(),
 
 		causes: e.Causes(),
 		buggy:  e.IsBug(),


### PR DESCRIPTION
Existing consumers of Errawr APIs will map the sensitivity to "none", which is no better or worse
than what they had before.